### PR TITLE
Include assert dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,8 @@
     "file-loader": "^6.0.0",
     "style-loader": "^2.0.0",
     "webpack-dev-server": "^3.0.0",
-    "webpack-cli": "~4.3.0"
+    "webpack-cli": "~4.3.0",
+    "assert": "^2.0.0"
   },
   "dependencies": {
     "backbone": "1.4.0",


### PR DESCRIPTION
Breaking change. webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. We need to include modules explicitly.